### PR TITLE
Only deploy docs on pushes to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           mkdocs build
       - name: Deploy docs
         uses: peaceiris/actions-gh-pages@v3
+        if: "github.event_name == 'push' && github.ref == 'refs/heads/master'"
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site


### PR DESCRIPTION
Deploying docs for PRs will fail because `secrets.GITHUB_TOKEN` is unavailable. Deploying docs for branches most likely isn't intended either.