### PR TITLE
fix QmlBot object has no attribute waitSignal

### DIFF
--- a/src/pytestqml/qmlbot.py
+++ b/src/pytestqml/qmlbot.py
@@ -46,7 +46,7 @@ class QmlBot(QObject):
         check_params_cb=None,
     ):
         self._should_raise = lambda x: x  # qtbot hack
-        return QtBot.wait_signal(
+        return QtBot.waitSignal(
             self,
             signal=signal,
             timeout=timeout,


### PR DESCRIPTION
fixes incompatibility introduced in pytest-qt 4.0.0